### PR TITLE
Add zenodo config

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,35 @@
+{
+  "upload_type": "dataset",
+  "creators": [
+    {
+      "orcid": "0000-0003-0551-6690",
+      "affiliation": "Delft University of Technology",
+      "name": "Olsthoorn, Mitchell"
+    },
+    {
+      "orcid": "0009-0003-7843-2372",
+      "affiliation": "Delft University of Technology",
+      "name": "Stallenberg, Dimitri"
+    },
+    {
+      "orcid": "0000-0002-7395-3588",
+      "affiliation": "Delft University of Technology",
+      "name": "Panichella, Annibale"
+    }
+  ],
+  "access_right": "open",
+  "license": "Apache-2.0",
+  "keywords": [
+    "syntest",
+    "syntest-framework",
+    "testing",
+    "search-based-software-engineering",
+    "search-based-software-testing",
+    "automated-test-generation"
+  ],
+  "communities": [
+    {
+      "identifier": "syntest"
+    }
+  ]
+}


### PR DESCRIPTION
The Zenodo configuration file automatically configures the Zenodo metadata for the software entity publication.